### PR TITLE
Fix CSS not loading on custom domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,6 @@
 # which you are expected to set up once and rarely need to edit after that.
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # `jekyll serve`. If you change this file, please restart the server process.
-# theme                  : "minimal-mistakes-jekyll"
-theme                  : "minima"
 remote_theme           : "mmistakes/minimal-mistakes"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
@@ -15,7 +13,7 @@ title                    : "Waleed Iqbal"
 title_separator          : "-"
 name                     : &name "Waleed Iqbal"
 description              : &description "PhD Candidate"
-url                      : https://waleediqbal411.github.io/ # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
+url                      : https://www.waleediqbal.info # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : "" # the subpath of your site, e.g. "/blog"
 repository               : "waleediqbal411/waleediqbal411.github.io"
 teaser                   :  # filename of teaser fallback teaser image placed in /images/, .e.g. "500x300.png"


### PR DESCRIPTION
## Summary

- Set `_config.yml` `url` to `https://www.waleediqbal.info` (the custom domain in `CNAME`) so generated absolute links stay same-origin HTTPS.
- Drop the stale `theme: "minima"` line that shadowed the active `remote_theme: mmistakes/minimal-mistakes`.

## Why

The site is served at `https://www.waleediqbal.info/`, but `_config.yml` had `url: https://waleediqbal411.github.io/`. The head template emits absolute stylesheet links from `site.url`, so pages referenced `https://waleediqbal411.github.io//assets/css/main.css`. GitHub Pages 301-redirected that to `http://www.waleediqbal.info//assets/css/main.css` — **HTTP, not HTTPS**. The browser blocked the redirect target as mixed content on the HTTPS page, so no CSS loaded. Confirmed via:

```
$ curl -sIv "https://waleediqbal411.github.io//assets/css/main.css"
< HTTP/2 301
< location: http://www.waleediqbal.info//assets/css/main.css
$ curl -sI "https://www.waleediqbal.info/assets/css/main.css"
HTTP/2 200
content-type: text/css; charset=utf-8
```

Pointing `url` at the actual origin makes the generated link same-origin HTTPS, no redirect, no mixed-content block. This also fixes the doubled-slash artifacts (`...github.io//assets/...`) and the `<canonical>` / `og:url` / sitemap / feed URLs that all derived from the wrong base.

## Test plan

- [ ] After GH Pages rebuilds, view source on https://www.waleediqbal.info/ and confirm `<link rel="stylesheet" href="https://www.waleediqbal.info/assets/css/main.css">` (same origin, single slash).
- [ ] Page renders styled (Minimal Mistakes theme), no mixed-content warnings in DevTools console.
- [ ] `<link rel="canonical">`, `og:url`, and sitemap entries use `https://www.waleediqbal.info/...`.

## Reviewer notes

- The repo also has an empty `.gitmodules` and the CI checkout step is failing with `No url found for submodule path '.claude/worktrees/admiring-gould-05bce6' in .gitmodules`. That's pre-existing — `.claude/worktrees/...` should never be tracked (it's an agent worktree), and `.gitmodules` should be deleted. Not part of this PR; flagging for a separate cleanup.