### PR TITLE
Show years on education cards

### DIFF
--- a/data/authors/me.yaml
+++ b/data/authors/me.yaml
@@ -51,6 +51,7 @@ interests:
 education:
   - degree: PhD Computer Science
     institution: Queen Mary University of London
+    year: '2020 – 2024'
     date_start: '2020-09-01'
     date_end: '2024-11-30'
     summary: |
@@ -59,6 +60,7 @@ education:
       manifestations of real-world inequalities.
   - degree: MSc Computer Science
     institution: Information Technology University, Lahore, Pakistan
+    year: '2016 – 2018'
     date_start: '2016-09-01'
     date_end: '2018-06-30'
     summary: |
@@ -66,6 +68,7 @@ education:
       computer networking research.
   - degree: BSc Electrical Engineering
     institution: University of The Punjab, Lahore, Pakistan
+    year: '2010 – 2014'
     date_start: '2010-09-01'
     date_end: '2014-02-28'
     summary: |


### PR DESCRIPTION
## Summary

- The resume-biography-3 block renders a `year` field directly below each degree on the homepage Education cards. `me.yaml` only set `date_start`/`date_end`, neither of which the template reads — so the cards displayed no dates at all.
- Adds a `year` string (e.g. `2020 – 2024`) to each of the three education entries in `data/authors/me.yaml`. `date_start`/`date_end` are kept for any other consumers.

## Test plan

- [ ] Run `hugo server` locally and confirm each Education card now shows the year range between the degree title and institution.
- [ ] Verify the rest of the homepage (About, Interests, News) renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)